### PR TITLE
Normalize save paths across OSes

### DIFF
--- a/src/client/java/com/j0ker2j0ker/swd/client/util/SaveManager.java
+++ b/src/client/java/com/j0ker2j0ker/swd/client/util/SaveManager.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.Locale;
 
 public class SaveManager {
 
@@ -55,8 +56,9 @@ public class SaveManager {
             }else {
                 name = SwdClient.CONFIG.saveWorldTo;
             }
-            path = mc.getLevelStorage().getSavesDirectory().resolve(name).toString();
-            regionPath = Paths.get(path, "region").toString();
+            Path resolvedPath = mc.getLevelStorage().getSavesDirectory().resolve(name);
+            path = normalizePathForOs(resolvedPath);
+            regionPath = normalizePathForOs(Paths.get(path, "region"));
 
             try {
                 if(!Files.exists(Path.of(path))) {
@@ -386,6 +388,16 @@ public class SaveManager {
             }
         }
         return data;
+    }
+
+    private static String normalizePathForOs(Path path) {
+        String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+        String normalized = path.toAbsolutePath().normalize().toString();
+        if (os.contains("win")) return normalized;
+        if (os.contains("mac") || os.contains("darwin") || os.contains("nux") || os.contains("nix")) {
+            return normalized.replace('\\', '/');
+        }
+        return normalized.replace('\\', '/');
     }
 
     private record ChunkSaveTask(ChunkPos pos, NbtCompound nbt) {


### PR DESCRIPTION
This pull request introduces improvements to path handling in the `SaveManager` class to ensure compatibility across different operating systems. The main change is the addition of a method to normalize file paths, which is now used when constructing save paths, enhancing cross-platform reliability.

**Cross-platform path normalization:**

* Added the `normalizePathForOs` method to `SaveManager`, which normalizes file paths based on the detected operating system to ensure consistent path formatting.
* Updated the logic in the `start` method to use `normalizePathForOs` when resolving save and region directory paths, replacing direct string conversion.
* Imported `Locale` to support OS name normalization in path handling.

The purpose of the pull request is to fix a bug where worlds generated by mods are saved in the wrong location. 