### PR TITLE
massively improve player data saving

### DIFF
--- a/src/client/java/com/j0ker2j0ker/swd/client/util/SaveManager.java
+++ b/src/client/java/com/j0ker2j0ker/swd/client/util/SaveManager.java
@@ -19,7 +19,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
-import net.minecraft.world.entity.player.Abilities;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.Biomes;
@@ -47,8 +46,9 @@ import net.minecraft.world.level.chunk.LevelChunkSection;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.PalettedContainer;
 import net.minecraft.world.level.chunk.Strategy;
+import net.minecraft.world.level.storage.LevelStorageSource;
+import net.minecraft.world.level.storage.PlayerDataStorage;
 import net.minecraft.world.level.storage.TagValueOutput;
-import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.inventory.MerchantMenu;
 import net.minecraft.world.item.trading.MerchantOffers;
 import net.minecraft.world.entity.npc.villager.AbstractVillager;
@@ -84,20 +84,12 @@ public class SaveManager {
             .withZone(ZoneId.systemDefault());
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 
-    private static final String OVERWORLD = "overworld";
-    private static final String NETHER = "the_nether";
-    private static final String END = "the_end";
-
-
     private static final Queue<ChunkSaveTask> saveQueue = new ConcurrentLinkedQueue<>();
     public static Thread saveThread = null;
 
     public static volatile boolean isSaving = false;
     public static String name;
     public static Path path;
-
-    private static CompoundTag cacheRootTag;
-    private static Path cachePlayerDatPath;
 
     private static HashMap<BlockPos, List<ItemStack>> cacheBlockInventories;
     private static HashMap<UUID, List<ItemStack>> cacheEntityInventories;
@@ -132,7 +124,7 @@ public class SaveManager {
 
         setupWorldFolder();
         if (SwdClient.CONFIG.includePlayerData) {
-            createPlayerDataCache(path);
+            createPlayerDataFile();
         }
 
         cacheBlockInventories = new HashMap<>();
@@ -158,7 +150,7 @@ public class SaveManager {
         flushPlayerMetaFiles(true);
         isSaving = false;
 
-        if (SwdClient.CONFIG.includePlayerData && cacheRootTag != null && cachePlayerDatPath != null) {
+        if (SwdClient.CONFIG.includePlayerData) {
             createPlayerDataFile();
         }
         printStatus(Component.translatable("swd.status.stopped_saving").withStyle(ChatFormatting.RED));
@@ -298,8 +290,15 @@ public class SaveManager {
         String title = screen.getTitle().getString();
 
         if (screen instanceof AbstractContainerScreen<?> container && title.equals(Component.translatable("container.enderchest").getString())) {
+            if (mc.player == null) return;
+
+            int slotIndex = 0;
+            for (ItemStack stack : container.getMenu().getItems()) {
+                if (slotIndex >= 27) break;
+                mc.player.getEnderChestInventory().setItem(slotIndex++, stack);
+            }
+
             printStatus(Component.translatable("swd.status.enderchest_saved").withStyle(ChatFormatting.GREEN));
-            cacheEnderItems(container.getMenu().getItems());
             return;
         }
 
@@ -675,174 +674,6 @@ public class SaveManager {
         }
     }
 
-    private static void createPlayerDataCache(Path path) {
-        Path playerdataPath;
-        try {
-            playerdataPath = Files.createDirectories(path.resolve("players").resolve("data"));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-
-        if (mc.level == null || mc.player == null) return;
-
-        CompoundTag root = new CompoundTag();
-
-        CompoundTag brain = new CompoundTag();
-        brain.put("memories", new ListTag());
-        root.put("Brain", brain);
-
-        root.putInt("HurtByTimestamp", 0);
-        root.putShort("SleepTimer", (short) mc.player.getSleepTimer());
-        if(mc.player.isInvulnerable()) root.putByte("Invulnerable", (byte) 1);
-        else root.putByte("Invulnerable", (byte) 0);
-        if(mc.player.isFallFlying()) root.putByte("FallFlying", (byte) 1);
-        else root.putByte("FallFlying", (byte) 0);
-        root.putInt("PortalCooldown", mc.player.getPortalCooldown());
-        root.putFloat("AbsorptionAmount", mc.player.getAbsorptionAmount());
-
-        CompoundTag abilities = new CompoundTag();
-        Abilities ab = mc.player.getAbilities();
-        if(ab.invulnerable) abilities.putByte("invulnerable", (byte) 1);
-        else  abilities.putByte("invulnerable", (byte) 0);
-        if(ab.mayfly) abilities.putByte("mayfly", (byte) 1);
-        else abilities.putByte("mayfly", (byte) 0);
-        if(ab.instabuild) abilities.putByte("instabuild", (byte) 1);
-        else abilities.putByte("instabuild", (byte) 0);
-        abilities.putFloat("walkSpeed", ab.getWalkingSpeed());
-        if (ab.mayBuild) abilities.putByte("mayBuild", (byte) 1);
-        else abilities.putByte("mayBuild", (byte) 0);
-        if(ab.flying) abilities.putByte("flying", (byte) 1);
-        else abilities.putByte("flying", (byte) 0);
-        abilities.putFloat("flySpeed", ab.getFlyingSpeed());
-        root.put("abilities", abilities);
-
-        CompoundTag recipeBook = new CompoundTag();
-        recipeBook.put("recipes", new ListTag());
-        recipeBook.put("toBeDisplayed", new ListTag());
-        root.put("recipeBook", recipeBook);
-
-        root.putShort("DeathTime", (short) mc.player.deathTime);
-        root.putInt("XpSeed", 0);
-        root.putInt("XpTotal", mc.player.totalExperience);
-        root.putIntArray("UUID",  new int[]{0, 0, 0, 0});
-        if(mc.player.gameMode() == null) root.putInt("playerGameType", 1);
-        else root.putInt("playerGameType", Objects.requireNonNull(mc.player.gameMode()).getId());
-        root.putByte("seenCredits", (byte) 0);
-
-        ListTag motion = new ListTag();
-        Vec3 currentMotion = mc.player.getDeltaMovement();
-        motion.add(DoubleTag.valueOf(currentMotion.x));
-        motion.add(DoubleTag.valueOf(currentMotion.y));
-        motion.add(DoubleTag.valueOf(currentMotion.z));
-        root.put("Motion", motion);
-
-        root.putFloat("Health", mc.player.getHealth());
-        root.putFloat("foodSaturationLevel", mc.player.getFoodData().getSaturationLevel());
-
-        CompoundTag equipment = new CompoundTag();
-        saveItem(mc.player.getInventory().getItem(39), ops).ifPresent(t -> equipment.put("head", t));
-        saveItem(mc.player.getInventory().getItem(38), ops).ifPresent(t -> equipment.put("chest", t));
-        saveItem(mc.player.getInventory().getItem(37), ops).ifPresent(t -> equipment.put("legs", t));
-        saveItem(mc.player.getInventory().getItem(36), ops).ifPresent(t -> equipment.put("feet", t));
-        saveItem(mc.player.getOffhandItem(), ops).ifPresent(t -> equipment.put("offhand", t));
-
-        root.put("equipment", equipment);
-
-        root.putDouble("fall_distance", mc.player.fallDistance);
-        root.putShort("Air", (short) mc.player.getAirSupply());
-        if(mc.player.onGround()) root.putByte("ground", (byte) 1);
-        else root.putByte("ground", (byte) 0);
-        root.putString("Dimension", mc.level.dimension().identifier().toString());
-
-        ListTag rotation = new ListTag();
-        rotation.add(FloatTag.valueOf(mc.player.getYRot()));
-        rotation.add(FloatTag.valueOf(mc.player.getXRot()));
-        root.put("Rotation", rotation);
-
-        root.putInt("XpLevel", mc.player.experienceLevel);
-        root.putInt("current_impulse_context_reset_grace_time", 0);
-
-        CompoundTag warden_spawn_tracker = new CompoundTag();
-        warden_spawn_tracker.putInt("warning_level", 0);
-        warden_spawn_tracker.putInt("ticks_since_last_warning", 380);
-        warden_spawn_tracker.putInt("cooldown_ticks", 0);
-        root.put("warden_spawn_tracker", warden_spawn_tracker);
-
-        root.putInt("Score", mc.player.getScore());
-
-        ListTag pos =  new ListTag();
-        pos.add(DoubleTag.valueOf(mc.player.getX()));
-        pos.add(DoubleTag.valueOf(mc.player.getY()));
-        pos.add(DoubleTag.valueOf(mc.player.getZ()));
-        root.put("Pos", pos);
-
-        root.putShort("Fire", (short) mc.player.getRemainingFireTicks());
-        root.putFloat("XpP", mc.player.experienceProgress);
-
-        ListTag attributes = new ListTag();
-
-        CompoundTag attributes0 = new CompoundTag();
-        attributes0.putString("id", "minecraft:waypoint_transmit_range");
-        attributes0.putDouble("base", 60000000);
-
-        CompoundTag attributes1 = new CompoundTag();
-        attributes1.putString("id", "minecraft:block_interaction_range");
-        attributes1.putDouble("base", 4.5);
-
-        CompoundTag attributes2 = new CompoundTag();
-        attributes2.putString("id", "minecraft:entity_interaction_range");
-        attributes2.putDouble("base", 3);
-
-        CompoundTag attributes3 = new CompoundTag();
-        attributes3.putString("id", "minecraft:movement_speed");
-        attributes3.putDouble("base", 0.10000000149011612);
-
-        attributes.add(attributes0);
-        attributes.add(attributes1);
-        attributes.add(attributes2);
-        attributes.add(attributes3);
-        root.put("attributes", attributes);
-
-        root.putInt("DataVersion", DATA_VERSION);
-        root.putInt("foodLevel", mc.player.getFoodData().getFoodLevel());
-        root.putFloat("foodExhaustionLevel", 0f);
-        root.putByte("spawn_extra_particles_on_fall", (byte) 0);
-        root.putShort("HurtTime", (short) mc.player.hurtTime);
-        root.putInt("SelectedItemSlot", mc.player.getInventory().getSelectedSlot());
-
-        ListTag inventory = new ListTag();
-        for (int slot = 0; slot < mc.player.getInventory().getContainerSize(); slot++) {
-            ItemStack stack = mc.player.getInventory().getItem(slot);
-            int finalSlot = slot;
-            saveItem(stack, ops).ifPresent(compound -> {
-                compound.putByte("Slot", (byte) finalSlot);
-                inventory.add(compound);
-            });
-        }
-        root.put("Inventory", inventory);
-
-        root.putInt("foodTickTimer", 0);
-
-        cachePlayerDatPath  = playerdataPath.resolve(mc.player.getStringUUID() + ".dat");
-        cacheRootTag = root;
-    }
-
-    public static void cacheEnderItems(List<ItemStack> items) {
-        if (!SwdClient.CONFIG.includePlayerData) return;
-        ListTag enderItems = new ListTag();
-        int i = 0;
-        for (ItemStack stack  : items) {
-            if(i>26) break;
-            int finalI = i;
-            saveItem(stack, ops).ifPresent(compound -> {
-                compound.putByte("Slot", (byte) finalI);
-                enderItems.add(compound);
-            });
-            i++;
-        }
-        cacheRootTag.put("EnderItems", enderItems);
-    }
-
     private static Optional<CompoundTag> saveItem(ItemStack stack, DynamicOps<Tag> ops) {
         if (stack == null || stack.isEmpty()) return Optional.empty();
 
@@ -887,7 +718,7 @@ public class SaveManager {
     }
 
     private static void writeStatsFile(Path statsFile) throws IOException {
-        if(!SwdClient.CONFIG.includePlayerData) return;
+        if (!SwdClient.CONFIG.includePlayerData) return;
         JsonObject existingRoot = readJsonObject(statsFile);
         JsonObject mergedStats = new JsonObject();
 
@@ -921,7 +752,7 @@ public class SaveManager {
     }
 
     private static void writeAdvancementsFile(Path advancementsFile) throws IOException {
-        if(!SwdClient.CONFIG.includePlayerData) return;
+        if (!SwdClient.CONFIG.includePlayerData) return;
         JsonObject existingRoot = readJsonObject(advancementsFile);
         JsonObject mergedRoot = new JsonObject();
 
@@ -1120,7 +951,9 @@ public class SaveManager {
 
     private static void createPlayerDataFile() {
         try {
-            NbtIo.writeCompressed(cacheRootTag, cachePlayerDatPath);
+            LevelStorageSource.LevelStorageAccess access = LevelStorageSource.createDefault(mc.getLevelSource().getBaseDir()).createAccess(name);
+            PlayerDataStorage playerStorage = access.createPlayerStorage();
+            playerStorage.save(mc.player);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This pr removes the entire player data file saving provided by the mod and offloads it onto minecraft itself.
This change not only decreases the size of the monolithic SaveManager class, which in turn makes it easier to maintain, along with more update stability.

Due to the offload, a lot of player data that was previously not saved (like attributes) now mirrors the server provided player data.
